### PR TITLE
Chapter_12: Reset_password

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,62 @@
+class PasswordResetsController < ApplicationController
+  before_action :get_user, :valid_user, :check_expiration, only: %i(edit update)
+
+  def new; end
+
+  def create
+    @user = User.find_by email: params[:password_reset][:email].downcase
+    if @user
+      @user.create_reset_digest
+      @user.send_password_reset_email
+      flash[:info] = t "pw_reset.noti.send_mail"
+      redirect_to root_url
+    else
+      flash.now[:danger] = t "pw_reset.noti.mail_fail"
+      render :new
+    end
+  end
+
+  def edit; end
+
+  def update
+    if user_params[:password].blank?
+      @user.errors.add :password, t("pw_reset.noti.pw_empty")
+      render :edit
+    elsif @user.update user_params
+      log_in @user
+      flash[:success] = t "pw_reset.noti.pw_pass"
+      redirect_to @user
+    else
+      flash[:danger] = t "pw_reset.noti.pw_fail"
+      render :edit
+    end
+  end
+
+  private
+
+  def get_user
+    @user = User.find_by email: params[:email]
+    return if @user
+
+    flash[:danger] = t "user.noti.show"
+    redirect_to root_url
+  end
+
+  def user_params
+    params.require(:user).permit :password, :password_confirmation
+  end
+
+  def valid_user
+    return if @user&.activated? && @user&.authenticated?(:reset, params[:id])
+
+    flash[:danger] = t "pw_reset.noti.invalid_user"
+    redirect_to root_url
+  end
+
+  def check_expiration
+    return unless @user.password_reset_expired?
+
+    flash[:danger] = t "pw_reset.noti.pw_expired"
+    redirect_to new_password_reset_url
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -4,9 +4,8 @@ class UserMailer < ApplicationMailer
     mail to: user.email, subject: t("activation.mailer.subject")
   end
 
-  # TODO
-  # def password_reset
-  #   @greeting = "Hi"
-  #   mail to: "to@example.org"
-  # end
+  def password_reset user
+    @user = user
+    mail to: user.email, subject: t("pw_reset.mailer.subject")
+  end
 end

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,0 +1,15 @@
+<% provide :title, t("pages.edit_pw.title") %>
+<h1><%= t "pages.edit_pw.title" %></h1>
+<div class="row">
+  <div class="col-md-6 offset-md-3">
+    <%= form_for @user, url: password_reset_path(params[:id]) do |f| %>
+      <%= render "shared/error_messages" %>
+      <%= hidden_field_tag :email, @user.email %>
+      <%= f.label :password, t("user.new.password") %>
+      <%= f.password_field :password, class: "form-control" %>
+      <%= f.label :password_confirmation, t("user.new.confirmation") %>
+      <%= f.password_field :password_confirmation, class: "form-control" %>
+      <%= f.submit t("pages.edit_pw.submit"), class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,0 +1,11 @@
+<% provide :title, t("pages.forgot_pw.title") %>
+<h1><%= t "pages.forgot_pw.title" %></h1>
+<div class="row">
+  <div class="col-md-6 offset-md-3">
+    <%= form_for :password_reset, url: password_resets_path do |f| %>
+      <%= f.label :email, t("user.new.email")  %>
+      <%= f.email_field :email, class: "form-control" %>
+      <%= f.submit t("pages.forgot_pw.submit"), class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -6,6 +6,7 @@
       <%= f.label :email, t("user.new.email") %>
       <%= f.email_field :email, class: "form-control" %>
       <%= f.label :password, t("user.new.password") %>
+      <%= link_to t("pages.login.forgot_pw"), new_password_reset_path %>
       <%= f.password_field :password, class: "form-control" %>
       <%= f.label :remember_me, class: "checkbox inline" do %>
         <%= f.check_box :remember_me %>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,0 +1,4 @@
+<h1><%= t "pw_reset.send_mail.title" %></h1>
+<p><%= t "pw_reset.send_mail.text_one" %></p>
+<%= link_to t("pw_reset.send_mail.title"), edit_password_reset_url(id: @user.reset_token, email: @user.email) %>
+<p><%= t "pw_reset.send_mail.text_two" %></p>

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,0 +1,3 @@
+<%= t "pw_reset.send_mail.text_one" %>
+<%= edit_password_reset_url id: @user.reset_token, email: @user.email %>
+<%= t "pw_reset.send_mail.text_two" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,6 +53,13 @@ en:
       title: "Log in"
       sign_up: "Sign Up Now!"
       remember_me: "Remember me on this computer"
+      forgot_pw: "(Forgot password)"
+    forgot_pw:
+      title: "Forgot password"
+      submit: "Submit"
+    edit_pw:
+      title: "Reset password"
+      submit: "Update password"
 # Controller and view user
   user:
     noti:
@@ -95,3 +102,21 @@ en:
       activate: "Activate"
       subject: "Account activation"
       title: "Sample App"
+# Controller PasswordResets
+  pw_reset:
+    noti:
+      send_mail: "Email sent with password reset instructions"
+      mail_fail: "Email address not found"
+      pw_empty: "can't be empty"
+      pw_pass:  "Password has been reset."
+      pw_fail: "Password update failed"
+      pw_expired: "Password reset has expired."
+      invalid_user: "The account has not been activated or the password reset code is invalid"
+    mailer:
+      subject: "Password reset"
+    send_mail:
+      title: "Password reset"
+      text_one: "To reset your password click the link below: "
+      text_two: "This link will expire in ten minutes.
+                  If you did not request your password to be reset, please ignore this email and
+                  your password will stay as it is. "

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -53,6 +53,13 @@ vi:
       title: "Đăng nhập"
       sign_up: "Đăng ký ngay"
       remember_me: "Ghi nhớ trên máy tính"
+      forgot_pw: "(Quên mật khẩu)"
+    forgot_pw:
+      title: "Quên mật khẩu"
+      submit: "Gửi"
+    edit_pw:
+      title: "Đặt lại mật khẩu"
+      submit: "Cập nhật mật khẩu"
 # Controller and view user
   user:
     noti:
@@ -95,3 +102,21 @@ vi:
       activate: "Kích hoạt"
       subject: "Kích hoạt tài khoản"
       title: "Ứng dụng mẫu"
+# Controller PasswordResets
+  pw_reset:
+    noti:
+      send_mail: "Kiểm tra email để đặt lại mật khẩu"
+      mail_fail: "Không tìm thấy địa chỉ email"
+      pw_empty: "không được để trống"
+      pw_pass:  "Mật khẩu đã được đặt lại"
+      pw_fail: "Cập nhật mật khẩu không thành công"
+      pw_expired: "Đặt lại mật khẩu đã hết hạn."
+      invalid_user: "Tài khoản chưa kích hoạt hoặc mã đặt lại mật khẩu không hợp lệ"
+    mailer:
+      subject: "Đặt lại mật khẩu"
+    send_mail:
+      title: "Đặt lại mật khẩu"
+      text_one: "Để đặt lại mật khẩu của bạn, hãy nhấp vào liên kết bên dưới: "
+      text_two: "Liên kết này sẽ hết hạn sau mười phút.
+                  Nếu bạn không yêu cầu đặt lại mật khẩu của mình, vui lòng bỏ qua email này và
+                  mật khẩu của bạn sẽ vẫn như cũ."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
 
     resources :users
     resources :account_activations, only: :edit
+    resources :password_resets, expect: %i(index show destroy)
 
     get "help", to: "static_pages#help"
     get "about", to: "static_pages#about"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,3 +22,4 @@ user:
   per_page: 10
 session:
   remember: "1"
+time_expired: 10

--- a/db/migrate/20200907110734_add_reset_to_users.rb
+++ b/db/migrate/20200907110734_add_reset_to_users.rb
@@ -1,0 +1,6 @@
+class AddResetToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :reset_digest, :string
+    add_column :users, :reset_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_06_031946) do
+ActiveRecord::Schema.define(version: 2020_09_07_110734) do
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", limit: 50, null: false
@@ -23,6 +23,8 @@ ActiveRecord::Schema.define(version: 2020_09_06_031946) do
     t.string "activation_digest"
     t.boolean "activated", default: false
     t.datetime "activated_at"
+    t.string "reset_digest"
+    t.datetime "reset_sent_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
# About

Chapter_12: Reset_password

# Technical changes

1. Tạo controller cho PasswordReset và config routes tương tự như xử lý gửi mail Active tài khoản, thì ở việc quên mật khẩu này, ta cũng thêm trường reset_diget để so khớp với token generate và gửi tới người dùng qua mailer, lưu reset_diget và reset_send_at (dùng để xem thời gian gửi mail, cũng như việc so sánh với một giá trị thời gian để có thể check dc mail hết hạn hay chưa) dưới db.
2. Gửi kèm token vào link điều hướng tới trang reset pw ( nếu email hợp lệ) mà người dùng đã nhập vào. 
3. Khi người dùng click vào link, nếu mail chưa active, hoặc reset_token sai, thì sẽ báo lỗi. True thì dẫn tới trang edit của controller password để cập nhật pw.

# Relative URL

# UI changes

![chap12](https://user-images.githubusercontent.com/70244857/92430976-82e0b200-f1c0-11ea-95da-9cd709935c02.png)

# TODO

Chapter 13